### PR TITLE
feat(tslint): use extends instead of rulesDirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Install from npm to your devDependencies:
 npm install --save-dev custom-tslint-rules
 ```
 
-Configure tslint to use the custom-tslint-rules folder:
+Configure tslint to extend the custom-tslint-rules configuration:
 
-Add the following path to the `rulesDirectory` setting in your `tslint.json` file:
+Add the following to the `extends` setting in your `tslint.json` file:
 
 ```json
 {
-   "rulesDirectory": [
-     "node_modules/custom-tslint-rules/dist"
+   "extends": [
+     "custom-tslint-rules"
    ],
    "rules": {
      ...

--- a/tslint.json
+++ b/tslint.json
@@ -1,4 +1,5 @@
 {
+  "rulesDirectory": ["./dist"],
   "rules": {
     "import-barrels": true,
     "jasmine-no-lambda-expression-callbacks": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,9 +6,9 @@
   version "4.14.64"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.64.tgz#979cf3a3d4a368670840bf9b3e448dc33ffe84ee"
 
-"@types/node@^7.0.18":
-  version "7.0.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.18.tgz#cd67f27d3dc0cfb746f0bdd5e086c4c5d55be173"
+"@types/node@^8.0.3":
+  version "8.0.14"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.14.tgz#4a19dc6bb61d16c01cbadc7b30ac23518fff176b"
 
 abbrev@1, abbrev@1.0.x:
   version "1.0.9"
@@ -1020,9 +1020,9 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@^2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.2.tgz#f0f045e196f69a72f06b25fd3bd39d01c3ce9984"
+typescript@~2.4.1:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.2.tgz#f8395f85d459276067c988aa41837a8f82870844"
 
 uglify-js@^2.6:
   version "2.7.5"


### PR DESCRIPTION
I misread the README and tried to use extends instead of rulesDirectory in `tslint.json` based on other TSLint config packages I use (tslint-config-prettier, tslint-microsoft-contrib, tslint-react). This commit changes custom-tslint-rules' configuration to use rulesDirectory internally, which then allows the user to add "custom-tslint-rules" to the extends property in `tslint.json`.

* https://palantir.github.io/tslint/2016/03/31/sharable-configurations-rules.html
* https://github.com/palantir/tslint-react/blob/3.0.0/tslint-react.json#L2
* https://github.com/alexjoverm/tslint-config-prettier#get-started
* https://github.com/Microsoft/tslint-microsoft-contrib/blob/b720cd9827a13c2878d304193544a5b030953ecb/tslint.json#L3

BREAKING CHANGE: this affects how users set up custom-tslint-rules, as they will need to change from rulesDirectory to extends in their own `tslint.json` confiigurations (as shown in the README), so I expect this to be a major breaking change (from 3.0.0 to 4.0.0).

---

No pressure in terms of merging this change (since this was born out of me not clearly reading the directions 😳), but I did want to open this to share feedback on the extends/rulesDirectory confusion I had (since I expect to use extends after installing custom tslint rule packages). And thank you for the import-barrels rule, planning to try it out on my team! 🙂